### PR TITLE
Use importlib-metadata not importlib_metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
@@ -23,7 +23,7 @@ requirements:
   run:
     - attrs >=17.4.0
     # TODO: upstream, this is conditional to <3.8, but probably not worth the non-noarch build
-    - importlib_metadata
+    - importlib-metadata
     - pyrsistent >=0.14.0
     # TODO: >3.2.0 sets this explicitly, but conda-forge no longer supports <3.6...
     - python >=3.6


### PR DESCRIPTION
importlib_metadata is a virtual package pointing to importlib-metadata use if you wish.