### PR TITLE
add outputs for format, format-nongpl, all (with tests)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,4 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
-zip_keys:
-- - cdt_name
-  - docker_image
+- quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema-green.svg)](https://anaconda.org/conda-forge/jsonschema) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema.svg)](https://anaconda.org/conda-forge/jsonschema) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema.svg)](https://anaconda.org/conda-forge/jsonschema) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema.svg)](https://anaconda.org/conda-forge/jsonschema) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema--with--format-green.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema-with-format.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema-with-format.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema-with-format.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema--with--format--nongpl-green.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema-with-format-nongpl.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema-with-format-nongpl.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema-with-format-nongpl.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) |
 
 Installing jsonschema
 =====================
@@ -43,10 +45,10 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `jsonschema` can be installed with:
+Once the `conda-forge` channel has been enabled, `jsonschema, jsonschema-with-format, jsonschema-with-format-nongpl` can be installed with:
 
 ```
-conda install jsonschema
+conda install jsonschema jsonschema-with-format jsonschema-with-format-nongpl
 ```
 
 It is possible to list all of the versions of `jsonschema` available on your platform with:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema-green.svg)](https://anaconda.org/conda-forge/jsonschema) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema.svg)](https://anaconda.org/conda-forge/jsonschema) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema.svg)](https://anaconda.org/conda-forge/jsonschema) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema.svg)](https://anaconda.org/conda-forge/jsonschema) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema--with--all-green.svg)](https://anaconda.org/conda-forge/jsonschema-with-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema-with-all.svg)](https://anaconda.org/conda-forge/jsonschema-with-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema-with-all.svg)](https://anaconda.org/conda-forge/jsonschema-with-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema-with-all.svg)](https://anaconda.org/conda-forge/jsonschema-with-all) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema--with--format-green.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema-with-format.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema-with-format.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema-with-format.svg)](https://anaconda.org/conda-forge/jsonschema-with-format) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jsonschema--with--format--nongpl-green.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jsonschema-with-format-nongpl.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jsonschema-with-format-nongpl.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jsonschema-with-format-nongpl.svg)](https://anaconda.org/conda-forge/jsonschema-with-format-nongpl) |
 
@@ -45,10 +46,10 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `jsonschema, jsonschema-with-format, jsonschema-with-format-nongpl` can be installed with:
+Once the `conda-forge` channel has been enabled, `jsonschema, jsonschema-with-all, jsonschema-with-format, jsonschema-with-format-nongpl` can be installed with:
 
 ```
-conda install jsonschema jsonschema-with-format jsonschema-with-format-nongpl
+conda install jsonschema jsonschema-with-all jsonschema-with-format jsonschema-with-format-nongpl
 ```
 
 It is possible to list all of the versions of `jsonschema` available on your platform with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "4.2.1" %}
 
 package:
-  name: jsonschema
+  name: jsonschema-meta
   version: {{ version }}
 
 source:
@@ -9,45 +9,100 @@ source:
   sha256: 390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8
 
 build:
-  number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  entry_points:
-    - jsonschema = jsonschema.cli:main
+  number: 0
 
 requirements:
   host:
     - python >=3.7
-    - pip
-    - setuptools-scm
   run:
-    - attrs >=17.4.0
-    # TODO: upstream, importlib-* are conditional to <3.8/9, but probably not worth the non-noarch builds
-    - importlib-metadata
-    - importlib_resources
-    - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
     - python >=3.7
 
-test:
-  files:
-    - start_test.py
-  source_files:
-    - json
-    - jsonschema/tests
-  requires:
-    - pip
-    - pytest-cov
-    - flask
-  imports:
-    - jsonschema
-  commands:
-    - pip check
-    - jsonschema --version
-    - jsonschema --help
-    - jsonschema --version | grep {{ version.replace(".", "\.") }}  # [unix]
-    # additional pytest args are set in start_test.py
-    - python start_test.py --cov-fail-under=93 -k "not find_validator_by_fully_qualified_object_name"
+outputs:
+  - name: jsonschema
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . --no-deps -vv
+      entry_points:
+        - jsonschema = jsonschema.cli:main
+    requirements:
+      host:
+        - python >=3.7
+        - pip
+        - setuptools-scm
+      run:
+        - attrs >=17.4.0
+        # TODO: upstream, importlib-* are conditional to <3.8/9, but probably not worth the non-noarch builds
+        - importlib-metadata
+        - importlib_resources
+        - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+        - python >=3.7
+    test:
+      requires:
+        - pip
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+        - jsonschema --version
+        - jsonschema --help
+        - jsonschema --version | grep {{ version.replace(".", "\.") }}  # [unix]
 
+  - name: jsonschema-with-format
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage('jsonschema') }}
+        - fqdn
+        - idna
+        - isoduration
+        - jsonpointer >1.13
+        - rfc3339-validator
+        - rfc3987
+        - uri-template
+        - webcolors >=1.11
+    test:
+      requires:
+        - pip
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+
+  - name: jsonschema-with-format-nongpl
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage('jsonschema') }}
+        - fqdn
+        - idna
+        - isoduration
+        - jsonpointer >1.13
+        - rfc3339-validator
+        - rfc3986-validator >0.1.0
+        - uri-template
+        - webcolors >=1.11
+    test:
+      files:
+        - start_test.py
+      source_files:
+        - json
+      requires:
+        - pip
+        - pytest-cov
+        - flask
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+        # additional pytest args are set in start_test.py
+        - python start_test.py --cov-fail-under=97
 
 about:
   home: https://github.com/Julian/jsonschema
@@ -59,6 +114,7 @@ about:
   dev_url: https://github.com/Julian/jsonschema
 
 extra:
+  feedstock-name: jsonschema
   recipe-maintainers:
     - minrk
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,6 +89,23 @@ outputs:
         - uri-template
         - webcolors >=1.11
     test:
+      requires:
+        - pip
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+
+  - name: jsonschema-with-all
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage('jsonschema-with-format-nongpl') }}
+        - {{ pin_subpackage('jsonschema-with-format') }}
+    test:
       files:
         - start_test.py
       source_files:

--- a/recipe/start_test.py
+++ b/recipe/start_test.py
@@ -10,11 +10,12 @@ os.environ.update(JSON_SCHEMA_TEST_SUITE=str(HERE / "json"))
 
 PYTEST_ARGS = [
     "-vv",
+    "--pyargs",
+    "jsonschema",
     "--cov=jsonschema",
     "--cov-report=term-missing:skip-covered",
     "--no-cov-on-fail",
     *sys.argv[1:],
-    "jsonschema/tests",
 ]
 
 print("PYTEST_ARGS", *PYTEST_ARGS)


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- fixes #27
- adds `-with-format-nongpl` and `-with-format` packages to track the `extras`
- moves full tests (63k, compressed) to an `-with-all` package 
  - it's unlikely anyone would _install_ this, as `format` and `format-nongpl` are basically alternatives, rather than complements
- blocked by
  - https://github.com/conda-forge/staged-recipes/pull/17170
  - https://github.com/conda-forge/staged-recipes/pull/17171
  - https://github.com/conda-forge/staged-recipes/pull/17172
  - https://github.com/conda-forge/staged-recipes/pull/17173 